### PR TITLE
plugins/license: Stop throwing error if package.json is missing

### DIFF
--- a/lib/plugins/license.js
+++ b/lib/plugins/license.js
@@ -18,11 +18,13 @@
 
 module.exports = (backend) => {
   return backend.readFile('package.json').then((packageJSON) => {
-    const npmLicense = JSON.parse(packageJSON).license
+    if (packageJSON) {
+      const npmLicense = JSON.parse(packageJSON).license
 
-    if (npmLicense) {
-      return {
-        license: npmLicense
+      if (npmLicense) {
+        return {
+          license: npmLicense
+        }
       }
     }
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Jack Brown <jack@resin.io>