### PR TITLE
faq: Collect whole content of the entry

### DIFF
--- a/lib/plugins/faq.js
+++ b/lib/plugins/faq.js
@@ -33,9 +33,15 @@ module.exports = (backend) => {
 
     tree.forEach((node, index) => {
       if (node[0] === 'header') {
+        const rest = tree.slice(index + 1)
+        const endIndex = _.findIndex(rest, (nextNode) => {
+          return _.first(node) === 'header' && nextNode[1].level === node[1].level
+        })
+        const content = rest.slice(0, endIndex)
+
         result.push({
           title: _.last(node),
-          content: tree[index + 1]
+          content
         })
       }
     })


### PR DESCRIPTION
We used to collect only the first element (usually a paragraph) ommiting any bullet-lists.

Change-type: patch