### PR TITLE
Don't try to log headers if they don't exist

### DIFF
--- a/lib/backends/github.js
+++ b/lib/backends/github.js
@@ -36,6 +36,9 @@ const debug = require('debug')(`${packageJSON.name}:backends:github`)
  * })
  */
 const logGitHubRateLimitingInformation = (headers) => {
+  if (!headers) {
+    return
+  }
   const resetDate = new Date(headers['x-ratelimit-reset'] * 1000)
   debug(`Rate limiting: ${headers['x-ratelimit-remaining']}/${
     headers['x-ratelimit-limit']


### PR DESCRIPTION
Fixes balena-io-modules/scrutinizer#125

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>