### PR TITLE
Allow unauthenticated requests to the GitHub API

### DIFF
--- a/lib/backends/github.js
+++ b/lib/backends/github.js
@@ -57,15 +57,17 @@ module.exports = class GitHubBackend {
    */
   constructor (repository, reference) {
     this.reference = reference
+
+    let auth
+
+    if (process.env.GITHUB_TOKEN) {
+      debug('Using $GITHUB_TOKEN as the authentication token')
+      auth = `token ${process.env.GITHUB_TOKEN}`
+    }
+
     this.github = new GitHub({
       UserAgent: packageJSON.name,
-      auth () {
-        if (process.env.GITHUB_TOKEN) {
-          debug('Using $GITHUB_TOKEN as the authentication token')
-          return `token ${process.env.GITHUB_TOKEN}`
-        }
-        return null
-      }
+      auth
     })
 
     const parsedUrl = repository.match(/([\w-]+)\/([\w-]+)(\.\w+)?$/)


### PR DESCRIPTION
Only set an octokit auth value if a token is available, otherwise octokit will try and authorize the request and fail.

Fixes balena-io-modules/scrutinizer#127
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>