### PR TITLE
Add plugin filter to local and remote calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Documentation
 | options | <code>Object</code> | options |
 | options.reference | <code>String</code> | git reference to check |
 | [options.progress] | <code>function</code> | progress callback (state) |
+| [options.whitelistPlugins] | <code>Array.&lt;String&gt;</code> | list of plugins to run. Matches all if empty |
 
 **Example**  
 ```js
@@ -69,6 +70,7 @@ GitHub to increase rate-limiting.
 | options | <code>Object</code> | options |
 | options.reference | <code>String</code> | git reference to check |
 | [options.progress] | <code>function</code> | progress callback (state) |
+| [options.whitelistPlugins] | <code>Array.&lt;String&gt;</code> | list of plugins to run. Matches all if empty |
 
 **Example**  
 ```js

--- a/bin/scrutinizer.js
+++ b/bin/scrutinizer.js
@@ -21,6 +21,7 @@
 const capitano    = require('capitano')
 const { join }    = require('path')
 const scrutinizer = require(join(__dirname, '../lib'))
+const _           = require('lodash')
 
 const showHelp = () => {
   console.error(`Usage: scrutinizer <path> [--reference=master]`)
@@ -47,6 +48,11 @@ const prettyPrint = obj => {
   console.log(JSON.stringify(obj, null, 2))
 }
 
+const parsePlugins = (plugins) => {
+  if (_.isUndefined(plugins) || !_.isString(plugins)) return []
+  return plugins.split(' ')
+}
+
 capitano.globalOption({
   signature: 'help',
   alias: ['h'],
@@ -71,28 +77,34 @@ capitano.command({
 })
 
 capitano.command({
-  signature: 'local <path>',
+  signature: 'local <path> [plugins...]',
   description: 'Retrieve metadata about a local checkout of a repo',
-  action: ({ path }, { help, reference = 'master' }) => {
+  action: ({ path, plugins }, { help, reference = 'master' }) => {
     if (help) {
       showHelp()
       process.exit(1)
     }
 
-    scrutinizer.local(path, { reference }).then(result => prettyPrint(result))
+    scrutinizer.local(path, {
+      reference,
+      whitelistPlugins: parsePlugins(plugins)
+    }).then(result => prettyPrint(result))
   }
 })
 
 capitano.command({
-  signature: 'remote <url>',
+  signature: 'remote <url> [plugins...]',
   description: 'Retrieve metadata about a remote repo. Set `GITHUB_TOKEN` as an env var for GitHub lookup',
-  action: ({ url }, { help, reference = 'master' }) => {
+  action: ({ url, plugins }, { help, reference = 'master' }) => {
     if (help) {
       showHelp()
       process.exit(1)
     }
 
-    scrutinizer.remote(url, { reference }).then(result => prettyPrint(result))
+    scrutinizer.remote(url, {
+      reference,
+      whitelistPlugins: parsePlugins(plugins)
+    }).then(result => prettyPrint(result))
   }
 })
 
@@ -102,4 +114,3 @@ capitano.run(process.argv, err => {
   showHelp()
   throw err
 })
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,30 +45,30 @@ const BACKENDS = {
  * @constant
  * @private
  */
-const BUILTIN_PLUGINS = [
-  require('./plugins/license'),
-  require('./plugins/blog'),
-  require('./plugins/changelog'),
-  require('./plugins/contributing'),
-  require('./plugins/contributors'),
-  require('./plugins/docs'),
-  require('./plugins/security'),
-  require('./plugins/faq'),
-  require('./plugins/code-of-conduct'),
-  require('./plugins/architecture'),
-  require('./plugins/maintainers'),
-  require('./plugins/readme'),
-  require('./plugins/readme-sections'),
-  require('./plugins/github-metadata'),
-  require('./plugins/dependencies'),
-  require('./plugins/last-commit-date'),
-  require('./plugins/latest-release'),
-  require('./plugins/latest-prerelease'),
-  require('./plugins/open-issues'),
-  require('./plugins/version'),
-  require('./plugins/screenshot'),
-  require('./plugins/logo')
-]
+const BUILTIN_PLUGINS = {
+  license: require('./plugins/license'),
+  blog: require('./plugins/blog'),
+  changelog: require('./plugins/changelog'),
+  contributing: require('./plugins/contributing'),
+  contributors: require('./plugins/contributors'),
+  docs: require('./plugins/docs'),
+  security: require('./plugins/security'),
+  faq: require('./plugins/faq'),
+  'code-of-conduct': require('./plugins/code-of-conduct'),
+  architecture: require('./plugins/architecture'),
+  maintainers: require('./plugins/maintainers'),
+  readme: require('./plugins/readme'),
+  'readme-sections': require('./plugins/readme-sections'),
+  'github-metadata': require('./plugins/github-metadata'),
+  dependencies: require('./plugins/dependencies'),
+  'last-commit-date': require('./plugins/last-commit-date'),
+  'latest-release': require('./plugins/latest-release'),
+  'latest-prerelease': require('./plugins/latest-prerelease'),
+  'open-issues': require('./plugins/open-issues'),
+  version: require('./plugins/version'),
+  screenshot: require('./plugins/screenshot'),
+  logo: require('./plugins/logo')
+}
 
 /**
  * @summary Examine a git repository
@@ -125,6 +125,7 @@ const examineGitRepository = (options) => {
  * @param {Object} options - options
  * @param {String} options.reference - git reference to check
  * @param {Function} [options.progress] - progress callback (state)
+ * @param {String[]} [options.whitelistPlugins] - list of plugins to run. Matches all if empty
  * @fulfil {Object} - examination results
  * @returns {Promise}
  *
@@ -161,7 +162,7 @@ exports.local = (gitRepository, options) => {
     return examineGitRepository({
       repository: temporaryRepository,
       backend: BACKENDS.fs,
-      plugins: BUILTIN_PLUGINS,
+      plugins: filterPlugins(options.whitelistPlugins),
       accumulator: {},
       progress: options.progress,
       reference: options.reference
@@ -182,6 +183,7 @@ exports.local = (gitRepository, options) => {
  * @param {Object} options - options
  * @param {String} options.reference - git reference to check
  * @param {Function} [options.progress] - progress callback (state)
+ * @param {String[]} [options.whitelistPlugins] - list of plugins to run. Matches all if empty
  * @fulfil {Object} - examination results
  * @returns {Promise}
  *
@@ -199,9 +201,31 @@ exports.remote = (gitRepository, options) => {
   return examineGitRepository({
     repository: gitRepository,
     backend: BACKENDS.github,
-    plugins: BUILTIN_PLUGINS,
+    plugins: filterPlugins(options.whitelistPlugins),
     accumulator: {},
     progress: options.progress,
     reference: options.reference
   })
+}
+
+/**
+ * @summary Filter whitelist from BUILTIN_PLUGINS
+ * @function
+ * @private
+ *
+ * @description
+ * Filter BUILTIN_PLUGINS based on a whitelisst
+ *
+ * @param {String[]} pluginWhitelist - list of plugins to whitelist
+ * @returns {Function[]}
+ *
+ * @example
+ * filterPlugins(['docs'])
+ */
+const filterPlugins = (pluginWhitelist) => {
+  let plugins = BUILTIN_PLUGINS
+  if (!_.isEmpty(pluginWhitelist)) {
+    plugins = _.pick(plugins, pluginWhitelist)
+  }
+  return _.values(plugins)
 }

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -36,7 +36,8 @@ _.each(CASES, (testCase) => {
   ava.test(`local: ${testCase.name} (${testCase.reference})`, (test) => {
     return scrutinizer.local(repositoryPath, {
       reference: testCase.reference,
-      progress: logProgress
+      progress: logProgress,
+      whitelistPlugins: testCase.plugins
     }).then((data) => {
       test.deepEqual(data, testCase.result)
     })
@@ -45,7 +46,8 @@ _.each(CASES, (testCase) => {
   ava.test(`remote: ${testCase.name} (${testCase.reference})`, (test) => {
     return scrutinizer.remote(testCase.url, {
       reference: testCase.reference,
-      progress: logProgress
+      progress: logProgress,
+      whitelistPlugins: testCase.plugins
     }).then((data) => {
       test.deepEqual(data, testCase.result)
     })

--- a/test/e2e/scrutinizer-test-repo-args.js
+++ b/test/e2e/scrutinizer-test-repo-args.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const data = {
+  name: 'scrutinizer-test-repo',
+  url: 'git@github.com:balena-io-modules/scrutinizer-test-repo',
+  reference: 'e789054c637c957fb837691f81e5227faa5ebd82',
+  plugins: [ 'docs', 'faq', 'github-metadata' ],
+  result: {
+    name: 'scrutinizer-test-repo',
+    description: 'A dummy repository to run scrutinizer\'s test suite against',
+    public: true,
+    fork: false,
+    stars: 0,
+    homepage: null,
+    repositoryUrl:
+      'https://github.com/balena-io-modules/scrutinizer-test-repo.git',
+    active: true,
+    owner: {
+      avatar: 'https://avatars0.githubusercontent.com/u/17724750?v=4',
+      handle: 'balena-io-modules',
+      url: 'https://github.com/balena-io-modules',
+      type: 'Organization'
+    },
+    docs: [
+      // eslint-disable-next-line max-len
+      { filename: 'docs/01-getting-started.md', contents: 'Getting Started\n===============\n\nWelcome to Landr! Setting up Landr in your project is extremely easy. First,\nmake sure you install the `landr` CLI from npmjs.org if you haven\'t already by\nrunning:\n\n```sh\nnpm install --global landr\n```\n\nLets also install the excellent [`serve`](https://www.npmjs.com/package/serve)\nstatic HTTP server as a way to preview our site:\n\n```sh\nnpm install --global serve\n```\n\nNow that everything is in place, head over to your project\'s repository and\nrun:\n\n```sh\nlandr build\n```\n\nGive it a bunch of seconds, and you should get various HTML, CSS, and\nJavaScript files in the `dist` directory. You can preview your site by running:\n\n```sh\nserve dist\n```\n\nAnd pointing your browser to `localhost:5000`.\n\nAt this point, you have working, but not perfect, website. Landr generates\nwebsites based on the content of the repository and relies on various OSS\nconventions for doing its job. Making sure your repository is well structured\nand follows the community conventions will do wonders for you website, and for\nyour repository overall!\n\nOnce you are happy with your site, run the following command to deploy to Netlify:\n\n```\nNETLIFY_AUTH_TOKEN=<token> landr deploy\n```\n\nPassing your Netlify authentication token as an environment variable.\n\nVersion 2\n' },
+      { filename: 'docs/02-dummy.md', contents: 'Dummy\n=====\n\nTest\n' }
+    ],
+    faq: null
+  }
+}
+
+module.exports = data

--- a/test/e2e/scrutinizer-test-repo.js
+++ b/test/e2e/scrutinizer-test-repo.js
@@ -4,6 +4,7 @@ const data = {
   name: 'scrutinizer-test-repo',
   url: 'git@github.com:balena-io-modules/scrutinizer-test-repo',
   reference: 'e789054c637c957fb837691f81e5227faa5ebd82',
+  plugins: [],
   result: {
     name: 'scrutinizer-test-repo',
     version: '1.5.0',


### PR DESCRIPTION
This allows to pass a list of required plugins, if this is provided only
those will run. This can be used to limit the amount of API calls
preformed by scrutinizer.

Change-type: minor
Signed-off-by: Giovanni Garufi <giovanni@balena.io>