### PR TITLE
MD is processed and returned as md instead of tree

### DIFF
--- a/lib/backends/github.js
+++ b/lib/backends/github.js
@@ -230,6 +230,29 @@ module.exports = class GitHubBackend {
   }
 
   /**
+   * @summary Get the repository URL
+   * @function
+   * @public
+   *
+   * @returns {Promise}
+   *
+   * @example
+   * const backend = new GitHubBackend(...)
+   * backend.getRepositoryUrl().then((url) => {
+   *   console.log(url)
+   * })
+   */
+  getRepositoryUrl () {
+    return this.getMetadata().then((results) => {
+      if (!results) {
+        return null
+      }
+
+      return results.repositoryUrl
+    })
+  }
+
+  /**
    * @summary Get the date of the last commit
    * @function
    * @public

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,6 +66,7 @@ const BUILTIN_PLUGINS = {
   'latest-prerelease': require('./plugins/latest-prerelease'),
   'open-issues': require('./plugins/open-issues'),
   version: require('./plugins/version'),
+  deployButtons: require('./plugins/deployButtons'),
   screenshot: require('./plugins/screenshot'),
   logo: require('./plugins/logo')
 }

--- a/lib/plugins/deployButtons.js
+++ b/lib/plugins/deployButtons.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 balena
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const Bluebird = require('bluebird')
+const { hasDeployButton } = require('../utils/markdown')
+
+const DEPLOY_WITH_BALENA_URL = 'https://dashboard.balena-cloud.com/deploy'
+
+module.exports = async(backend) => {
+  const files = await Bluebird.props({
+    readme: backend.readFile('README.md')
+  })
+  const repoUrl = await backend.getRepositoryUrl()
+  if (!repoUrl) {
+    return { deployWithBalenaUrl: null }
+  }
+
+  return {
+    deployWithBalenaUrl: hasDeployButton(files.readme, DEPLOY_WITH_BALENA_URL)
+      ? `${DEPLOY_WITH_BALENA_URL}?repoUrl=${repoUrl}`
+      : null
+  }
+}

--- a/lib/plugins/readme-sections.js
+++ b/lib/plugins/readme-sections.js
@@ -20,150 +20,11 @@ const Bluebird = require('bluebird')
 const _ = require('lodash')
 const markdown = require('markdown').markdown
 const { getScreenshot } = require('../utils/image')
+const { getMarkdownSection, getHighlights, getLeftoverSections, getInstallationSteps } = require('../utils/markdown')
 
 /**
- * @summary Get section from Readme
- * @function
- * @private
+ * TODO: convert this to normal markdown
  *
- * @param {String} readme - Readme file
- * @param {String} section - Section name
- * @returns {Object}
- *
- * @example
- * getReadmeSection(readme, section)
- */
-const getReadmeSection = (readme, section) => {
-  const tree = _.tail(markdown.parse(readme))
-  const startIndex = _.findIndex(tree, (node) => {
-    return _.first(node) === 'header' && _.last(node) === section
-  })
-
-  if (startIndex === -1) {
-    return null
-  }
-
-  const header = tree[startIndex]
-  const rest = tree.slice(startIndex + 1)
-  const endIndex = _.findIndex(rest, (node) => {
-    return _.first(node) === 'header' && node[1].level === header[1].level
-  })
-
-  const content = rest.slice(0, endIndex)
-
-  return content
-}
-
-/**
- * @summary Remove sections from readme
- * @function
- * @private
- *
- * @param {String} readme - Readme file
- * @param {String[]} sections - List of sections to remove
- * @returns {Object}
- *
- * @example
- * getReadmeLeftover(readme,sections)
- */
-const getReadmeLeftover = (readme, sections) => {
-  const tree = _.tail(markdown.parse(readme))
-  sections.forEach((section) => {
-    const startIndex = _.findIndex(tree, (node) => {
-      return _.first(node) === 'header' && _.last(node) === section
-    })
-
-    if (startIndex === -1) {
-      return null
-    }
-
-    const header = tree[startIndex]
-    const rest = tree.slice(startIndex + 1)
-    const endIndex = _.findIndex(rest, (node) => {
-      return _.first(node) === 'header' && node[1].level === header[1].level
-    })
-
-    return tree.splice(startIndex, endIndex - startIndex)
-  })
-  return tree
-}
-
-/**
- * @summary Get highlights from Readme
- * @function
- * @private
- *
- * @param {String} readme - Readme file
- * @returns {Object}
- *
- * @example
- * getHighlights(readme)
- */
-const getHighlights = (readme) => {
-  const content = getReadmeSection(readme, 'Highlights')
-
-  // eslint-disable-next-line lodash/matches-prop-shorthand
-  const listIndex = _.findIndex(content, (node) => {
-    return node[0] === 'bulletlist'
-  })
-
-  if (listIndex === -1) {
-    return null
-  }
-
-  return _.map(_.tail(content[listIndex]), (highlight) => {
-    // Removes the `bulletlist` modifier
-    const entry = highlight.slice(1)
-
-    // Get only the text, without the modifier (e.g. strong)
-    const title = entry[0][1]
-
-    // Get the whole JsonML entry, including links, text highlights, etc
-    const description = _.tail(entry)
-
-    // Remove the leftover delimiter
-    description[0] = description[0].replace(': ', '')
-
-    return {
-      title,
-      description
-    }
-  })
-}
-
-/**
- * @summary Get installation steps from Readme
- * @function
- * @private
- *
- * @param {String} readme - Readme file
- * @returns {Object}
- *
- * @example
- * getInstallationSteps(readme)
- */
-const getInstallationSteps = (readme) => {
-  const content = getReadmeSection(readme, 'Installation')
-
-  // eslint-disable-next-line lodash/matches-prop-shorthand
-  const listIndex = _.findIndex(content, (node) => {
-    return node[0] === 'numberlist'
-  })
-
-  if (listIndex === -1) {
-    return null
-  }
-
-  return {
-    headers: [],
-    steps: _.map(_.tail(content[listIndex]), (node) => {
-      return _.tail(node)
-    }),
-    footer: content.slice(listIndex + 1)
-  }
-}
-
-/**
  * @summary Get sites using the project from Readme
  * @function
  * @private
@@ -175,10 +36,14 @@ const getInstallationSteps = (readme) => {
  * getExamples(readme)
  */
 const getExamples = async(readme) => {
-  const content = getReadmeSection(readme, 'Examples')
+  const content = await getMarkdownSection(readme, 'Examples')
+  if (!content) {
+    return ''
+  }
+  const tree = _.tail(markdown.parse(content))
 
   // eslint-disable-next-line lodash/matches-prop-shorthand
-  const listIndex = _.findIndex(content, (node) => {
+  const listIndex = _.findIndex(tree, (node) => {
     return node[0] === 'bulletlist'
   })
 
@@ -187,7 +52,7 @@ const getExamples = async(readme) => {
   }
 
   const examples = await Bluebird.map(
-    _.tail(content[listIndex]),
+    _.tail(tree[listIndex]),
     async(highlight) => {
       const websiteUrl = highlight.slice(1)[0][1].href
 
@@ -222,14 +87,14 @@ module.exports = async(backend) => {
   }
 
   return {
-    highlights: getHighlights(readme),
-    installationSteps: getInstallationSteps(readme),
+    highlights: await getHighlights(readme),
+    installationSteps: await getInstallationSteps(readme),
     examples: await getExamples(readme),
-    motivation: getReadmeSection(readme, 'Motivation'),
-    hardwareRequired: getReadmeSection(readme, 'Hardware required'),
-    softwareRequired: getReadmeSection(readme, 'Software required'),
-    introduction: getReadmeSection(readme, 'Introduction'),
-    readmeLeftover: getReadmeLeftover(readme, [
+    motivation: await getMarkdownSection(readme, 'Motivation'),
+    hardwareRequired: await getMarkdownSection(readme, 'Hardware required'),
+    softwareRequired: await getMarkdownSection(readme, 'Software required'),
+    introduction: await getMarkdownSection(readme, 'Introduction'),
+    readmeLeftover: await getLeftoverSections(readme, [
       'Introduction',
       'Motivation',
       'Highlights',
@@ -237,6 +102,6 @@ module.exports = async(backend) => {
       'Installation',
       'Hardware required',
       'Software required'
-    ])
+    ], true)
   }
 }

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -298,9 +298,24 @@ const getInstallationSteps = async(markdown) => {
   }
 }
 
+/**
+ *@summary detects if deploy url exists in markdown
+ *
+ * @param {String} markdown - markdown
+ * @param {String} deployUrl - deployUrl
+ *
+ * @returns {Boolean}
+ * @example
+ * hasDeployUrl(markdown, deployUrl)
+ */
+const hasDeployButton = (markdown, deployUrl) => {
+  return markdown.includes(deployUrl)
+}
+
 module.exports = {
   getMarkdownSection,
   getHighlights,
   getLeftoverSections,
-  getInstallationSteps
+  getInstallationSteps,
+  hasDeployButton
 }

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2020 balena
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const unified = require('unified')
+const remarkParse = require('remark-parse')
+const remarkStringify = require('remark-stringify')
+const remark2rehype = require('remark-rehype')
+const raw = require('rehype-raw')
+const rehype2remark = require('rehype-remark')
+
+/**
+ * @summary return if node is a heading
+ * @function
+ * @private
+ *
+ * @param {Object} node - markdown node
+ * @returns {Boolean}
+ *
+ * @example
+ * isHeading(node)
+ */
+const isHeading = (node) => {
+  return node.type === 'heading'
+}
+
+/**
+ * @summary return if node is a paragraph
+ * @function
+ * @private
+ *
+ * @param {Object} node - markdown node
+ * @returns {Boolean}
+ *
+ * @example
+ * isHeading(node)
+ */
+const isParagraph = (node) => {
+  return node.type === 'paragraph'
+}
+
+/**
+ * @summary return if node is a paragraph
+ * @function
+ * @private
+ *
+ * @param {Object} node - markdown node
+ * @returns {Boolean}
+ *
+ * @example
+ * isHeading(node)
+ */
+const isImage = (node) => {
+  return node.type === 'image'
+}
+
+/**
+ *@summary unify content as only markdown, converting html into md.
+ *@function
+ *@private
+ *
+ * @param {String} markdown - markdown content
+ * @returns {Promise}
+ *
+ * @example
+ * convertHtmlToMD(markdown).then(md => console.log(md))
+ */
+const convertHtmlToMD = async(markdown) => {
+  return unified()
+    .use(remarkParse, { gfm: true })
+    .use(remark2rehype, { allowDangerousHtml: true })
+    .use(raw)
+    .use(rehype2remark)
+    .use(remarkStringify)
+    .process(markdown)
+}
+
+/**
+ * @summary Get section from Readme
+ * @function
+ * @private
+ *
+ * @param {String} readme - Readme file
+ * @param {String} heading - Section name
+ * @returns {Object}
+ *
+ * @example
+ * getMarkdownSection(readme, section)
+ */
+const getMarkdownSection = async(readme, heading) => {
+  const convertedMarkdown = await convertHtmlToMD(readme)
+
+  const mdast = unified()
+    .use(remarkParse, { gfm: true })
+    .parse(convertedMarkdown)
+
+  const startIndex = mdast.children.findIndex((node) => {
+    return (
+      isHeading(node) &&
+      node.children.some((childNode) => {
+        return childNode.value.toLowerCase() === heading.toLowerCase()
+      })
+    )
+  })
+
+  if (startIndex === -1) return ''
+
+  const restTree = mdast.children.slice(startIndex + 1)
+
+  let lastIndex = restTree.findIndex((node) => {
+    return isHeading(node) && node.depth === mdast.children[startIndex].depth
+  })
+
+  if (lastIndex === -1) {
+    lastIndex = restTree.length - 1
+  }
+
+  const tree = {
+    type: 'root',
+    children: mdast.children.slice(startIndex + 1, startIndex + lastIndex + 1)
+  }
+
+  return unified().use(remarkStringify).stringify(tree)
+}
+
+/**
+ * @summary Get highlights from Readme
+ * @function
+ * @private
+ *
+ * @param {String} readme - Readme file
+ * @returns {Object}
+ *
+ * @example
+ * getHighlights(readme)
+ */
+const getHighlights = async(readme) => {
+  const content = await getMarkdownSection(readme, 'Highlights')
+
+  const mdast = unified().use(remarkParse, { gfm: true }).parse(content)
+
+  const listIndex = mdast.children.findIndex((node) => {
+    return node.type === 'list'
+  })
+
+  if (listIndex === -1) {
+    return ''
+  }
+
+  return mdast.children[listIndex].children
+    .map((highlight) => {
+      return {
+        title: highlight.children[0].children[0],
+        description: highlight.children[0].children[1]
+      }
+    })
+    .map((highlight) => {
+      return {
+        title: unified().use(remarkStringify).stringify(highlight.title),
+        description:
+          unified().use(remarkStringify).stringify(highlight.description) || ''
+      }
+    })
+    .map((highlight) => {
+      return {
+        title: highlight.title,
+        description: highlight.description.startsWith(':')
+          ? highlight.description.replace(':', '')
+          : highlight.description
+      }
+    })
+}
+
+/**
+ * @summary Remove sections from readme
+ * @function
+ * @private
+ *
+ * @param {String} readme - Readme file
+ * @param {String[]} sections - List of sections to remove
+ * @param {Boolean} removeFirstImage - remove first image
+ * @returns {Object}
+ *
+ * @example
+ * getReadmeLeftover(readme,sections)
+ */
+const getLeftoverSections = async(
+  readme,
+  sections,
+  removeFirstImage = false
+) => {
+  const content = await convertHtmlToMD(readme)
+
+  const mdast = unified().use(remarkParse, { gfm: true }).parse(content)
+
+  sections.forEach((section) => {
+    const startIndex = mdast.children.findIndex((node) => {
+      return (
+        isHeading(node) &&
+        node.children.some((child) => {
+          return child.value.toLowerCase() === section.toLowerCase()
+        })
+      )
+    })
+
+    if (startIndex === -1) {
+      return
+    }
+
+    const header = mdast.children[startIndex]
+    const rest = mdast.children.slice(startIndex + 1)
+    let endIndex = rest.findIndex((node) => {
+      return isHeading(node) && node.depth === header.depth
+    })
+
+    if (endIndex === -1) endIndex = rest.length - 1
+
+    mdast.children.splice(startIndex, endIndex + 1)
+  })
+
+  if (removeFirstImage) {
+    const imageIndex = mdast.children.findIndex((node) => {
+      return (
+        isParagraph(node) &&
+        node.children.some((childNode) => {
+          return isImage(childNode)
+        })
+      )
+    })
+
+    if (imageIndex !== -1) {
+      mdast.children.splice(imageIndex, 1)
+    }
+  }
+
+  return unified().use(remarkStringify).stringify(mdast)
+}
+
+/**
+ *
+ * @summary Get installation steps from markdown
+ * @function
+ * @private
+ *
+ * @param {String} markdown - markdown file
+ * @returns {Object}
+ *
+ * @example
+ * getInstallationSteps(markdown)
+ */
+const getInstallationSteps = async(markdown) => {
+  const content = await getMarkdownSection(markdown, 'Installation')
+
+  if (!content) {
+    return null
+  }
+
+  const mdast = unified().use(remarkParse, { gfm: true }).parse(content)
+
+  let steps = []
+
+  let footer = null
+
+  const listIndex = mdast.children.findIndex((node) => {
+    return node.type === 'list' && node.ordered
+  })
+
+  if (listIndex === -1) {
+    return null
+  }
+
+  steps = mdast.children[listIndex].children.map((listNode) => {
+    return unified().use(remarkStringify).stringify({ type: 'root', children: listNode.children })
+  })
+
+  footer = unified()
+    .use(remarkStringify)
+    .stringify({ type: 'root', children: mdast.children.slice(listIndex + 1) })
+
+  return {
+    headers: [],
+    steps,
+    footer
+  }
+}
+
+module.exports = {
+  getMarkdownSection,
+  getHighlights,
+  getLeftoverSections,
+  getInstallationSteps
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "test": "npm run lint && nyc --reporter=lcov ava",
+    "watch:test": "ava --watch",
     "readme": "jsdoc2md --template doc/README.hbs lib/index.js > README.md",
     "lint": "eslint --ignore-pattern /test/repositories/* lib test",
     "lint-fix": "eslint --ignore-pattern /test/repositories/* lib test --fix"
@@ -56,14 +57,14 @@
     "rehype-raw": "^4.0.2",
     "rehype-remark": "^8.0.0",
     "rehype-stringify": "^8.0.0",
+    "sharp": "^0.25.4",
+    "unified-stream": "^1.0.6",
     "remark-parse": "^8.0.2",
     "remark-rehype": "^7.0.0",
     "remark-stringify": "^8.1.0",
-    "sharp": "^0.25.4",
     "simple-git": "^1.85.0",
     "tesseract.js": "^2.1.1",
     "tmp": "0.0.33",
-    "unified": "^9.0.0",
-    "unified-stream": "^1.0.6"
+    "unified": "^9.0.0"
   }
 }

--- a/test/e2e/scrutinizer-test-repo.js
+++ b/test/e2e/scrutinizer-test-repo.js
@@ -1,5 +1,94 @@
 'use strict'
 
+/* eslint-disable max-len */
+
+const readmeLeftover = `# scrutinizer-test-repo
+
+This repository serves as a playground for [Scrutinizer](https://github.com/balena-io-modules/scrutinizer).
+
+Scrutinizer's test suite relies on various metadata including 'Integrations' and more. These properties can change at any time in an active project. Consequently, this repository will serve as a predictable point of reference for our tests.
+`
+
+const docsContent = `Getting Started
+===============
+
+Welcome to Landr! Setting up Landr in your project is extremely easy. First,
+make sure you install the \`landr\` CLI from npmjs.org if you haven't already by
+running:
+
+\`\`\`sh
+npm install --global landr
+\`\`\`
+
+Lets also install the excellent [\`serve\`](https://www.npmjs.com/package/serve)
+static HTTP server as a way to preview our site:
+
+\`\`\`sh
+npm install --global serve
+\`\`\`
+
+Now that everything is in place, head over to your project's repository and
+run:
+
+\`\`\`sh
+landr build
+\`\`\`
+
+Give it a bunch of seconds, and you should get various HTML, CSS, and
+JavaScript files in the \`dist\` directory. You can preview your site by running:
+
+\`\`\`sh
+serve dist
+\`\`\`
+
+And pointing your browser to \`localhost:5000\`.
+
+At this point, you have working, but not perfect, website. Landr generates
+websites based on the content of the repository and relies on various OSS
+conventions for doing its job. Making sure your repository is well structured
+and follows the community conventions will do wonders for you website, and for
+your repository overall!
+
+Once you are happy with your site, run the following command to deploy to Netlify:
+
+\`\`\`
+NETLIFY_AUTH_TOKEN=<token> landr deploy
+\`\`\`
+
+Passing your Netlify authentication token as an environment variable.
+
+Version 2
+`
+
+const docsDummyContent = `Dummy
+=====
+
+Test
+`
+
+const contributing = `This is a placeholder file.
+
+We strongly urge you to checkout [Scrutinizer](https://github.com/balena-io-modules/scrutinizer) instead.
+`
+
+const blogContent = `# Dummy article
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis nec nisi ligula. Cras orci nulla, venenatis vel tincidunt sed, tristique eget lorem. Pellentesque sit amet blandit elit, in tincidunt augue. Proin hendrerit dolor purus, a tincidunt eros porttitor sed. Integer libero nibh, auctor id eros fermentum, dignissim maximus tellus. In nulla ligula, dapibus sed nisi et, fringilla imperdiet justo. Sed volutpat ligula non sapien ornare tempus. Vivamus tincidunt dapibus placerat. Vestibulum eu sem lorem. Maecenas massa lacus, tempus vitae tempus quis, laoreet at leo. Vivamus placerat vestibulum diam, ac gravida lectus pretium at. Nullam gravida justo libero, sed ornare nulla cursus et. Curabitur ac neque sit amet lacus congue consectetur. Etiam varius facilisis lacus, sed bibendum libero interdum id. Pellentesque vitae pharetra massa. Cras ut sapien id turpis semper commodo.
+
+In non suscipit mi, non finibus nunc. Vivamus vehicula venenatis sapien, vitae dictum elit maximus non. Quisque bibendum facilisis nibh, at bibendum turpis porta vel. Curabitur finibus faucibus orci id rutrum. Nulla et dictum neque. Aenean suscipit mattis tempus. Ut id risus tristique, semper turpis sed, hendrerit neque. Vivamus tellus metus, pellentesque at sapien non, vulputate aliquet elit. Donec sodales ligula augue. Duis fermentum libero massa, quis egestas nibh pellentesque eget. Ut at consequat urna. Sed non diam dapibus, rutrum neque ac, pretium nulla. Proin finibus pulvinar varius. Vestibulum eget tincidunt lorem.
+
+Version 2
+`
+
+const readme = `scrutinizer-test-repo
+===========
+
+This repository serves as a playground for [Scrutinizer](https://github.com/balena-io-modules/scrutinizer).
+
+Scrutinizer's test suite relies on various metadata including 'Integrations' and more. These properties can change at any time in an active project. Consequently, this repository will serve as a predictable point of reference for our tests.
+`
+/* eslint-enable */
+
 const data = {
   name: 'scrutinizer-test-repo',
   url: 'git@github.com:balena-io-modules/scrutinizer-test-repo',
@@ -18,8 +107,7 @@ const data = {
       'https://github.com/balena-io-modules/scrutinizer-test-repo.git',
     active: true,
     license: 'Apache-2.0',
-    contributing:
-      'This is a placeholder file.\n\nWe strongly urge you to checkout [Scrutinizer](https://github.com/balena-io-modules/scrutinizer) instead.\n',
+    contributing,
     architecture: null,
     security: null,
     lastCommitDate: '2019-09-17T13:42:54Z',
@@ -42,50 +130,28 @@ const data = {
       url: 'https://github.com/balena-io-modules',
       type: 'Organization'
     },
-    examples: null,
-    highlights: null,
-    motivation: null,
+    examples: '',
+    highlights: '',
+    motivation: '',
     installationSteps: null,
-    hardwareRequired: null,
-    softwareRequired: null,
-    introduction: null,
-    readmeLeftover: [
-      [
-        'header',
-        {
-          level: 1
-        },
-        'scrutinizer-test-repo'
-      ],
-      [
-        'para',
-        'This repository serves as a playground for ',
-        [
-          'link',
-          {
-            href: 'https://github.com/balena-io-modules/scrutinizer'
-          },
-          'Scrutinizer'
-        ],
-        '.'
-      ],
-      [
-        'para',
-        // eslint-disable-next-line max-len
-        'Scrutinizer\'s test suite relies on various metadata including \'Integrations\' and more. These properties can change at any time in an active project. Consequently, this repository will serve as a predictable point of reference for our tests.'
-      ]
-    ],
+    hardwareRequired: '',
+    softwareRequired: '',
+    introduction: '',
+    readmeLeftover,
     docs: [
-      // eslint-disable-next-line max-len
-      { filename: 'docs/01-getting-started.md', contents: 'Getting Started\n===============\n\nWelcome to Landr! Setting up Landr in your project is extremely easy. First,\nmake sure you install the `landr` CLI from npmjs.org if you haven\'t already by\nrunning:\n\n```sh\nnpm install --global landr\n```\n\nLets also install the excellent [`serve`](https://www.npmjs.com/package/serve)\nstatic HTTP server as a way to preview our site:\n\n```sh\nnpm install --global serve\n```\n\nNow that everything is in place, head over to your project\'s repository and\nrun:\n\n```sh\nlandr build\n```\n\nGive it a bunch of seconds, and you should get various HTML, CSS, and\nJavaScript files in the `dist` directory. You can preview your site by running:\n\n```sh\nserve dist\n```\n\nAnd pointing your browser to `localhost:5000`.\n\nAt this point, you have working, but not perfect, website. Landr generates\nwebsites based on the content of the repository and relies on various OSS\nconventions for doing its job. Making sure your repository is well structured\nand follows the community conventions will do wonders for you website, and for\nyour repository overall!\n\nOnce you are happy with your site, run the following command to deploy to Netlify:\n\n```\nNETLIFY_AUTH_TOKEN=<token> landr deploy\n```\n\nPassing your Netlify authentication token as an environment variable.\n\nVersion 2\n' },
-      { filename: 'docs/02-dummy.md', contents: 'Dummy\n=====\n\nTest\n' }
+      {
+        filename: 'docs/01-getting-started.md',
+        contents: docsContent
+      },
+      { filename: 'docs/02-dummy.md', contents: docsDummyContent }
     ],
     blog: [
-      // eslint-disable-next-line max-len
-      { filename: 'blog/2019-07-08-hello-from-scrutinizer.md', contents: '# Dummy article\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Duis nec nisi ligula. Cras orci nulla, venenatis vel tincidunt sed, tristique eget lorem. Pellentesque sit amet blandit elit, in tincidunt augue. Proin hendrerit dolor purus, a tincidunt eros porttitor sed. Integer libero nibh, auctor id eros fermentum, dignissim maximus tellus. In nulla ligula, dapibus sed nisi et, fringilla imperdiet justo. Sed volutpat ligula non sapien ornare tempus. Vivamus tincidunt dapibus placerat. Vestibulum eu sem lorem. Maecenas massa lacus, tempus vitae tempus quis, laoreet at leo. Vivamus placerat vestibulum diam, ac gravida lectus pretium at. Nullam gravida justo libero, sed ornare nulla cursus et. Curabitur ac neque sit amet lacus congue consectetur. Etiam varius facilisis lacus, sed bibendum libero interdum id. Pellentesque vitae pharetra massa. Cras ut sapien id turpis semper commodo.\n\nIn non suscipit mi, non finibus nunc. Vivamus vehicula venenatis sapien, vitae dictum elit maximus non. Quisque bibendum facilisis nibh, at bibendum turpis porta vel. Curabitur finibus faucibus orci id rutrum. Nulla et dictum neque. Aenean suscipit mattis tempus. Ut id risus tristique, semper turpis sed, hendrerit neque. Vivamus tellus metus, pellentesque at sapien non, vulputate aliquet elit. Donec sodales ligula augue. Duis fermentum libero massa, quis egestas nibh pellentesque eget. Ut at consequat urna. Sed non diam dapibus, rutrum neque ac, pretium nulla. Proin finibus pulvinar varius. Vestibulum eget tincidunt lorem.\n\nVersion 2\n' }
+      {
+        filename: 'blog/2019-07-08-hello-from-scrutinizer.md',
+        contents: blogContent
+      }
     ],
-    readme:
-      'scrutinizer-test-repo\n===========\n\nThis repository serves as a playground for [Scrutinizer](https://github.com/balena-io-modules/scrutinizer).\n\nScrutinizer\'s test suite relies on various metadata including \'Integrations\' and more. These properties can change at any time in an active project. Consequently, this repository will serve as a predictable point of reference for our tests.\n',
+    readme,
     changelog: [
       {
         commits: [

--- a/test/e2e/scrutinizer-test-repo.js
+++ b/test/e2e/scrutinizer-test-repo.js
@@ -113,6 +113,7 @@ const data = {
     lastCommitDate: '2019-09-17T13:42:54Z',
     latestRelease: null,
     latestPreRelease: null,
+    deployWithBalenaUrl: null,
     dependencies: [
       '@octokit/rest',
       'bluebird',

--- a/test/plugins/readme.spec.js
+++ b/test/plugins/readme.spec.js
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 balena
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const ava = require('ava')
+const {
+  getMarkdownSection,
+  getHighlights,
+  getLeftoverSections,
+  getInstallationSteps
+} = require('../../lib/utils/markdown')
+
+/* eslint-disable max-len */
+const fullTest = `
+![](https://raw.githubusercontent.com/balena-io-projects/balena-sound/master/images/balenaSound-logo.png)
+
+**Starter project enabling you to add multi-room audio streaming via Bluetooth, Airplay or Spotify Connect to any old speakers or Hi-Fi using just a Raspberry Pi.**
+
+# Highlights
+
+- **Bluetooth, Airplay, Spotify Connect and UPnP**: Stream audio from your favorite music services or directly from your smartphone/computer using bluetooth or UPnP.
+- **Multi-room synchronous playing**: Play perfectly synchronized audio on multiple devices all over your place.
+- **Extended DAC support**: Upgrade your audio quality with one of our supported DACs
+
+# Examples
+
+example
+
+# Introduction
+
+introduction
+
+# Motivation
+
+motivation para _one_
+
+**Strong** content
+
+
+# Installation
+
+1. installation step 1
+2. installation step 2
+3. installation step 3
+
+footer content of the installation
+
+# Hardware required
+
+hardware
+
+# Setup and configuration
+
+Running this project is as simple as deploying it to a balenaCloud application. You can do it in just one click by using the button below:
+
+[![](https://balena.io/deploy.png)](https://dashboard.balena-cloud.com/deploy)
+
+# Software required
+
+software
+
+# Documentation
+
+Head over to our [docs](https://sound.balenalabs.io) for detailed installation and usage instructions, customization options and more!
+
+`
+const motivationContent = `motivation para _one_
+
+**Strong** content
+`
+
+const setupContent = `Running this project is as simple as deploying it to a balenaCloud application. You can do it in just one click by using the button below:
+
+[![](https://balena.io/deploy.png)](https://dashboard.balena-cloud.com/deploy)
+`
+
+const readmeLeftoverContent = `**Starter project enabling you to add multi-room audio streaming via Bluetooth, Airplay or Spotify Connect to any old speakers or Hi-Fi using just a Raspberry Pi.**
+
+# Setup and configuration
+
+Running this project is as simple as deploying it to a balenaCloud application. You can do it in just one click by using the button below:
+
+[![](https://balena.io/deploy.png)](https://dashboard.balena-cloud.com/deploy)
+
+# Documentation
+
+Head over to our [docs](https://sound.balenalabs.io) for detailed installation and usage instructions, customization options and more!
+`
+
+/* eslint-enable */
+
+ava.test('given a header extracts content until next header', async(test) => {
+  const response = await getMarkdownSection(fullTest, 'Motivation')
+  test.is(response, motivationContent)
+})
+
+ava.test(
+  'given a header extracts content until the last line',
+  async(test) => {
+    const response = await getMarkdownSection(
+      fullTest,
+      'Setup and configuration'
+    )
+    test.is(response, setupContent)
+  }
+)
+
+ava.test('extracts highlights as list of markdown', async(test) => {
+  const response = await getHighlights(fullTest)
+  test.deepEqual(response, [
+    {
+      title: '**Bluetooth, Airplay, Spotify Connect and UPnP**',
+      description:
+        ' Stream audio from your favorite music services or directly from your smartphone/computer using bluetooth or UPnP.'
+    },
+    {
+      title: '**Multi-room synchronous playing**',
+      description:
+        ' Play perfectly synchronized audio on multiple devices all over your place.'
+    },
+    {
+      title: '**Extended DAC support**',
+      description: ' Upgrade your audio quality with one of our supported DACs'
+    }
+  ])
+})
+
+ava.test('removes provided sections from markdown', async(test) => {
+  const response = await getLeftoverSections(
+    fullTest,
+    [
+      'Introduction',
+      'Motivation',
+      'Highlights',
+      'Examples',
+      'Installation',
+      'Hardware required',
+      'Software required'
+    ],
+    true
+  )
+  test.is(
+    response,
+    readmeLeftoverContent
+  )
+})
+
+ava.test('extracts installation steps from markdown', async(test) => {
+  const response = await getInstallationSteps(fullTest)
+
+  test.deepEqual(response, {
+    headers: [],
+    steps: [
+      'installation step 1\n',
+      'installation step 2\n',
+      'installation step 3\n'
+    ],
+    footer: 'footer content of the installation\n'
+  })
+})


### PR DESCRIPTION
Markdown is now returned from readme plugins as markdown instead of JSON Trees.
This enables us to handle the content as markdown where needed.
This is a **breaking change** since it content dependent of JSON tree will
not render/ throw error.

We now detect and report deploy with balena URLs

Change-type: Major
Signed-off-by: Amit Solanki <amit@balena.io>